### PR TITLE
Add Snyk badge; use HTML to align badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # SmartThings SmartApp SDK Java (Preview) ![SmartThings](docs/smartthings-logo.png) ![Java](docs/java-logo.png)
 
-[![CircleCI](https://circleci.com/gh/SmartThingsCommunity/smartapp-sdk-java/tree/master.svg?style=svg&circle-token=21da1691c64a0b734e55ada5d591b477347a2936)](https://circleci.com/gh/SmartThingsCommunity/smartapp-sdk-java/tree/master) [![codecov](https://codecov.io/gh/SmartThingsCommunity/smartapp-sdk-java/branch/master/graph/badge.svg?token=Zy5sgPRzLd)](https://codecov.io/gh/SmartThingsCommunity/smartapp-sdk-java)
+<p align="center">
+<a href="https://circleci.com/gh/SmartThingsCommunity/smartapp-sdk-java/tree/master"><img src="https://circleci.com/gh/SmartThingsCommunity/smartapp-sdk-java/tree/master.svg?style=svg&circle-token=21da1691c64a0b734e55ada5d591b477347a2936" /></a>
+<a href="https://codecov.io/gh/SmartThingsCommunity/smartapp-sdk-java"><img src="https://codecov.io/gh/SmartThingsCommunity/smartapp-sdk-java/branch/master/graph/badge.svg?token=Zy5sgPRzLd"></a>
+<a href="https://snyk.io/test/github/SmartThingsCommunity/smartapp-sdk-java"><img src="https://snyk.io/test/github/SmartThingsCommunity/smartapp-sdk-java/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/SmartThingsCommunity/smartapp-sdk-java" style="max-width:100%;"></a>
+</p>
 
 > **Welcome!**  This SDK is currently in _**preview**_ and is not recommended for use in production applications at this time. We welcome your bug reports, feature requests, and contributions.
 


### PR DESCRIPTION
This PR adds the Snyk.io dependency vulnerability analyzer badge to the readme. 

And, bringing this readme in line with our other public repo readmes,  the badges are not centered (using inline HTML). 