### PR TITLE
Conditionally apply publish-jar.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,5 +18,8 @@ allprojects {
             configurations.findAll { it.canBeResolved }.files
         }
     }
+}
 
+configure(subprojects.findAll {it.name != 'examples'}) {
+    apply from: rootProject.file('gradle/publish-jar.gradle')
 }

--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -1,3 +1,7 @@
+if (!project.hasProperty('sonatypeUsername') || !project.hasProperty('sonatypePassword')) {
+    return
+}
+
 apply plugin: "maven-publish"
 apply plugin: "signing"
 

--- a/smartapp-core/build.gradle
+++ b/smartapp-core/build.gradle
@@ -19,7 +19,6 @@ apply plugin: 'idea'
 apply plugin: 'groovy'
 apply plugin: 'eclipse'
 apply from: rootProject.file('gradle/convention.gradle')
-apply from: rootProject.file('gradle/publish-jar.gradle')
 
 repositories {
     jcenter()

--- a/smartapp-guice/build.gradle
+++ b/smartapp-guice/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'eclipse'
 apply from: rootProject.file('gradle/convention.gradle')
-apply from: rootProject.file('gradle/publish-jar.gradle')
 
 dependencies {
     implementation deps.projects.smartappcore

--- a/smartapp-spring/build.gradle
+++ b/smartapp-spring/build.gradle
@@ -4,8 +4,6 @@ plugins {
 }
 
 apply from: rootProject.file('gradle/convention.gradle')
-apply from: rootProject.file('gradle/publish-jar.gradle')
-
 
 dependencies {
     compile deps.projects.smartappcore

--- a/smartthings-client/build.gradle
+++ b/smartthings-client/build.gradle
@@ -20,7 +20,6 @@ apply plugin: 'org.ysb33r.vfs'
 apply plugin: 'org.hidetake.swagger.generator'
 apply plugin: 'eclipse'
 apply from: rootProject.file('gradle/convention.gradle')
-apply from: rootProject.file('gradle/publish-jar.gradle')
 apply from: rootProject.file('gradle/dependencies.gradle')
 
 repositories {


### PR DESCRIPTION
This PR should fix the CI errors present due to required environment/project variables not existing for certain build jobs. 

Explanation of bug that this fixes: 
- `publish-jar.gradle` requires properties `sonatypeUsername`
- `publish-jar.gradle` is applied to projects and evaluated to add to Gradle task graph
- PR Check job does not need to publish, so the variables are not added to that job's context
- PR Check job fails because the values are omitted

Fix:
- `publish-jar.gradle`: If those properties are missing at runtime, do not apply plugin (any job except `tag`s)
- `publish-jar.gradle`: If those properties are there at runtime, apply plugin (signifies a `tag`)