### PR TITLE
add DynamoDB to Spring Boot example README and fix a few URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the public SmartThings REST API.
 ## Prerequisites
 
 * Java 1.8+
-* SmartThings developer account
+* [SmartThings developer](https://smartthings.developer.samsung.com/workspace/) account
 
 ## Adding the SDK to your build
 

--- a/examples/java-lambda-smartapp/README.md
+++ b/examples/java-lambda-smartapp/README.md
@@ -6,7 +6,7 @@ This sample demonstrates a simple [Java](https://www.oracle.com/java/) server us
 ## Requirements
 
 * Java 1.8
-* [SmartThings developer](https://devworkspace.developer.samsung.com) account
+* [SmartThings developer](https://smartthings.developer.samsung.com/workspace/) account
 * [Amazon Web Services](https://aws.amazon.com/) account
 
 ## Installing the Example

--- a/examples/java-ratpack-guice-smartapp/README.md
+++ b/examples/java-ratpack-guice-smartapp/README.md
@@ -7,7 +7,7 @@ for dependency injection.
 ## Requirements
 
 * Java 1.8+
-* SmartThings developer account
+* [SmartThings developer](https://smartthings.developer.samsung.com/workspace/) account
 
 ## Running the Example
 

--- a/examples/java-springboot-smartapp/README.md
+++ b/examples/java-springboot-smartapp/README.md
@@ -6,7 +6,8 @@ This sample demonstrates a simple [Java](https://www.oracle.com/java/) server us
 ## Requirements
 
 * Java 1.8+
-* SmartThings developer account
+* [SmartThings developer](https://smartthings.developer.samsung.com/workspace/) account
+* [Amazon Web Services](https://aws.amazon.com/) account
 
 ## Running the Example
 
@@ -26,22 +27,43 @@ SmartApp in the developer console. You will need to restart once configured.
 Follow these steps using the
 [developer workspace](https://smartthings.developer.samsung.com/workspace/):
 
-  1. Create a new project and choose "Automation for the SmartThings App".
-  1. Give your project a unique name.
-  1. Choose "Automation Connector | SmartApp" under "Develop" in the left-hand menu.
-  1. Choose "WebHook Endpoint" and enter the URL of your endpoint and click "Next".
-  1. Select the `r:devices:*` and `x:devices:*` scopes and click "Next".
-  1. Give your application a name and hit "Save". Note that at this point, you
-     will need to have the application running. (See Build and Run above.)
-  1. Save the public key created to a file called `smartthings_rsa.pub` in the
-     `src/main/resources` directory.
-  1. In `src/main/resources`, copy `application.yml.example` to `application.yml`
-     and update the client id and client secret with values from your newly
-     created smartapp. If the secret is hidden, hit "regenerate" to get a new
-     client id and client secret.
-  1. Save the new project and click the "Deploy to Test" button.
-  1. Restart your server (see [Build and Run](#build-and-run) above). (This is
-     necessary because we added the configuration options above.)
+1. Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html).
+1. Configure the CLI to use your account.
+
+    1. Create a user with DynamoDB permissions.
+
+        1. Find "My Security Credentials" under your account settings.
+        1. Click on "Users" and then "Add User".
+        1. Give the user a name like "DynamoDB", choose "programmatic" access for the access type and click "Next".
+        1. Choose "Attach existing policies directly", find and add "AmazonDynamoDBFullAccess" and click "Next".
+        1. Click "Next" on the tags page.
+        1. Click "Create User".
+        1. Copy and save both the key id and the key secret.
+
+    1. Run `aws configure` and populate as follows:
+        | Option                | Value                               |
+        |-----------------------|-------------------------------------|
+        | AWS Access Key ID     | id from above                       |
+        | AWS Secret Access Key | secret from above                   |
+        | Default region name   | choose an [AWS region](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) geographically close to your end-user's location |
+        | Default output format | enter 'json' here                   |
+
+1. Create a new project and choose "Automation for the SmartThings App".
+1. Give your project a unique name.
+1. Choose "Automation Connector | SmartApp" under "Develop" in the left-hand menu.
+1. Choose "WebHook Endpoint" and enter the URL of your endpoint and click "Next".
+1. Select the `r:devices:*` and `x:devices:*` scopes and click "Next".
+1. Give your application a name and hit "Save". Note that at this point, you
+   will need to have the application running. (See Build and Run above.)
+1. Save the public key created to a file called `smartthings_rsa.pub` in the
+   `src/main/resources` directory.
+1. In `src/main/resources`, copy `application.yml.example` to `application.yml`
+   and update the client id and client secret with values from your newly
+   created smartapp. If the secret is hidden, hit "regenerate" to get a new
+   client id and client secret.
+1. Save the new project and click the "Deploy to Test" button.
+1. Restart your server (see [Build and Run](#build-and-run) above). (This is
+   necessary because we added the configuration options above.)
 
 ### Install SmartApp
 

--- a/examples/java-springboot-smartapp/src/main/java/app/handlers/AppConfigurationHandler.java
+++ b/examples/java-springboot-smartapp/src/main/java/app/handlers/AppConfigurationHandler.java
@@ -53,7 +53,7 @@ public class AppConfigurationHandler implements ConfigurationHandler {
                     .type(SettingType.PASSWORD);
                 SectionSetting booleanSetting = new BooleanSetting()
                     .id("booleanTest")
-                    .name("Yes or no, 1 or 0, true or false, set on not set")
+                    .name("Yes or no, 1 or 0, true or false, set or not set")
                     .description("To choose or not to choose, that is the question")
                     .type(SettingType.BOOLEAN);
                 Section settingsTestSection = new Section()

--- a/examples/kotlin-smartapp/README.md
+++ b/examples/kotlin-smartapp/README.md
@@ -3,7 +3,7 @@
 This sample demonstrates a simple [Kotlin](https://kotlinlang.org/)-based server using [Ktor](https://ktor.io) as a web server.
 
 * Java 1.8+
-* SmartThings developer account
+* [SmartThings developer](https://smartthings.developer.samsung.com/workspace/) account
 
 ## Running the Example
 

--- a/smartapp-contextstore-dynamodb/README.md
+++ b/smartapp-contextstore-dynamodb/README.md
@@ -7,9 +7,9 @@ in a `DefaultInstalledAppContext` instance.
 ## Prerequisites
 
 * Java 1.8+
-* Amazon AWS account
+* [SmartThings developer](https://smartthings.developer.samsung.com/workspace/) account
+* [Amazon Web Services](https://aws.amazon.com/) account
 * [smartapp-core](../smartapp-core)
-* SmartThings developer account
 
 ## Adding the library to your build
 

--- a/smartapp-core/README.md
+++ b/smartapp-core/README.md
@@ -7,7 +7,7 @@ This library aims to make developing your own JVM-based SmartApps easy, intuitiv
 ## Prerequisites
 
 * Java 1.8+
-* SmartThings developer account
+* [SmartThings developer](https://smartthings.developer.samsung.com/workspace/) account
 
 ## Adding the library to your build
 

--- a/smartapp-guice/README.md
+++ b/smartapp-guice/README.md
@@ -7,7 +7,7 @@ This is a simple library to make declaring Smart App lifecycle handlers as Googl
 * Java 1.8+
 * Google Guice 4.2+
 * [smartapp-core](../smartapp-core)
-* SmartThings developer account
+* [SmartThings developer](https://smartthings.developer.samsung.com/workspace/) account
 
 ## Adding the library to your build
 

--- a/smartapp-spring/README.md
+++ b/smartapp-spring/README.md
@@ -7,7 +7,7 @@ This is a simple library to make declaring Smart App lifecycle handlers as Sprin
 * Java 1.8+
 * Spring 4+
 * [smartapp-core](../smartapp-core)
-* SmartThings developer account
+* [SmartThings developer](https://smartthings.developer.samsung.com/workspace/) account
 
 ## Adding the library to your build
 

--- a/smartthings-client/README.md
+++ b/smartthings-client/README.md
@@ -5,7 +5,7 @@ Interact with the SmartThings public REST API with this _Java and Android-compat
 ## Prerequisites
 
 * Java 1.8+
-* SmartThings developer account
+* [SmartThings developer](https://smartthings.developer.samsung.com/workspace/) account
 
 ## Adding the library to your build
 


### PR DESCRIPTION
This is purely a documentation update:

* added AWS/DynamoDB instructions to the Spring Boot example README that were overlooked
* fixed (and added) URLs for the dev workspace